### PR TITLE
docs: expand README with overview and local build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# Discope Documentation
+# Documentation de Discope
+
+Ce dépôt contient la documentation officielle de l'application Discope. Elle explique les concepts clés, décrit les fonctionnalités majeures et aide les nouveaux contributeurs à comprendre l'organisation du projet.
+
+## Prévisualisation locale
+
+1. Installer les dépendances :
+
+   ```bash
+   pip install mkdocs mkdocs-material mike
+   ```
+
+2. Lancer le serveur de développement :
+
+   ```bash
+   mkdocs serve
+   ```
+
+   La documentation est alors disponible sur `http://127.0.0.1:8000`.
+
+3. Générer la version statique :
+
+   ```bash
+   mkdocs build
+   ```
+
+## Sections principales
+
+- `docs/setup.md` : procédure d'installation et de configuration.
+- `docs/concepts.md` : notions et terminologie essentielles.
+- `docs/application-description/index.md` : vue d'ensemble des modules de l'application.
+


### PR DESCRIPTION
## Summary
- update README with a French overview of Discope documentation
- describe how to preview the site locally using MkDocs
- point to main documentation sections for orientation

## Testing
- `mkdocs build`
- `mkdocs serve`

------
https://chatgpt.com/codex/tasks/task_b_68931a342f6c8325a36e3ab411a7f76a