### PR TITLE
Use level-two headings in documentation

### DIFF
--- a/docs/concepts/centers.md
+++ b/docs/concepts/centers.md
@@ -1,4 +1,4 @@
-# Centres
+## Centres
 
 Un centre est une entité administrative qui regroupe les unités locatives d'un même établissement.
 Il agrège les bâtiments qui en dépendent et sa capacité correspond à la somme des capacités des unités locatives qui le composent.

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,4 +1,4 @@
-# Concepts
+## Concepts
 
 Aperçu des notions principales utilisées dans Discope.
 

--- a/docs/concepts/organization.md
+++ b/docs/concepts/organization.md
@@ -1,4 +1,4 @@
-# Organisation
+## Organisation
 
 Discope gère les activités d'une ou plusieurs organisations dont l'objectif est la location d'unités locatives de divers types : bâtiments, salles, chambres et lits.
 Chaque organisation fournit le cadre administratif pour la gestion des centres et des équipes associées.

--- a/docs/concepts/rental_units.md
+++ b/docs/concepts/rental_units.md
@@ -1,4 +1,4 @@
-# Unités locatives
+## Unités locatives
 
 Une unité locative est tout espace ou équipement d'un centre pouvant faire l'objet d'une réservation.
 Elle comprend les logements (bâtiments, chambres, lits) ainsi que les ressources non résidentielles comme les salles de réunion ou le mobilier.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
-# Bienvenue dans Discope
+## Bienvenue dans Discope
 
 Discope est une plateforme qui gère les réservations, les ressources et la communication pour les organisations exploitant des centres d'hébergement. Le projet couvre tout, de la gestion des réservations à la comptabilité et aux rapports.
 
-## Structure de la documentation
+### Structure de la documentation
 
 - [Concepts](concepts/index.md) : vue d'ensemble des notions et de la terminologie.
 - [Installation et configuration](setup/index.md) : guide pour mettre en place une nouvelle instance de Discope.

--- a/docs/setup/accounting.md
+++ b/docs/setup/accounting.md
@@ -1,4 +1,4 @@
-# Configuration « Compta »
+## Configuration « Compta »
 
 Cela permet de définir le plan et les règles comptables. Cette section se trouve dans Finances/Compta.
 

--- a/docs/setup/communication.md
+++ b/docs/setup/communication.md
@@ -1,4 +1,4 @@
-# Configuration « Communication »
+## Configuration « Communication »
 
 - **Templates** : La configuration de template permet de créer des modèles d'emails à envoyer aux clients, comprenant une section pour l'objet et une pour le corps du message. Ces modèles sont associés à une catégorie spécifique et à un type, tel que devis, contrat ou facture. Par défaut, une catégorie de modèle est définie et les modèles peuvent inclure des fichiers joints spécifiés.
 

--- a/docs/setup/emails.md
+++ b/docs/setup/emails.md
@@ -1,4 +1,4 @@
-# Configuration des emails
+## Configuration des emails
 
 **1. Compte email principal pour l'envoi**
 

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -1,8 +1,8 @@
-# Installation et configuration
+## Installation et configuration
 
 Cette section reprend les différentes étapes pour la configuration initiale d'une nouvelle instance de Discope pour laquelle seules les données obligatoires d'initialisation ont été intégrées.
 
-## Sections
+### Sections
 
 - [Configuration de Sécurité](security.md)
 - [Configuration de l'organisation](organization.md)

--- a/docs/setup/organization.md
+++ b/docs/setup/organization.md
@@ -1,4 +1,4 @@
-# Configuration de l'organisation
+## Configuration de l'organisation
 
 - **Organisation :** Par défaut, l'organisation est déjà créée avec l'identificateur 1. Il est nécessaire d'ajouter le nom, le type, l'email, le numéro de téléphone, le numéro d'entreprise, ainsi que l'adresse complète (pays, ville, rue, numéro et code postal).
 

--- a/docs/setup/prices.md
+++ b/docs/setup/prices.md
@@ -1,3 +1,3 @@
-# Configuration des prix
+## Configuration des prix
 
 - **Liste de prix** : La configuration de la liste de prix permet de gérer les tarifs applicables sur des périodes spécifiques et selon des catégories de services. La liste doit être définie une fois par an. Chaque entrée inclut un identifiant, un statut, des dates de validité et la durée, garantissant l'application des tarifs corrects pour chaque catégorie de liste de prix.

--- a/docs/setup/product_catalog.md
+++ b/docs/setup/product_catalog.md
@@ -1,4 +1,4 @@
-# Configuration du catalogue des produits
+## Configuration du catalogue des produits
 
 - **Produits** : La configuration des produits permet d'associer chaque produit à un modèle spécifique, garantissant ainsi un SKU unique pour une identification précise. Chaque produit doit comporter un libellé descriptif, un SKU, un modèle de produit correspondant, ainsi que des informations clés telles que son statut de vente, sa possibilité d'être inclus dans un pack et la famille à laquelle il appartient. De plus, un produit peut regrouper plusieurs autres produits, formant ainsi un pack. Enfin, il peut avoir plusieurs prix selon différentes listes de prix.
 

--- a/docs/setup/sales.md
+++ b/docs/setup/sales.md
@@ -1,4 +1,4 @@
-# Configuration de Ventes
+## Configuration de Ventes
 
 Cette option permet de définir les paramètres pour les réservations, les réductions et les produits automatiques.
 

--- a/docs/setup/security.md
+++ b/docs/setup/security.md
@@ -1,4 +1,4 @@
-# Configuration de Sécurité
+## Configuration de Sécurité
 
 Cet aspect permet d'établir les permissions et restrictions pour les utilisateurs assignés à un groupe. Elle se trouve dans l'option Base, puis dans Sécurité.
 

--- a/docs/setup/settings.md
+++ b/docs/setup/settings.md
@@ -1,3 +1,3 @@
-# Configuration des paramètres
+## Configuration des paramètres
 
 Cette configuration se trouve dans l'option « Configuration », puis dans « Paramètres ». Par défaut, certains paramètres sont déjà définis, tels que le format de date, le format d'affichage des prix, la présentation des numéros et les traductions dans différentes langues. Il est possible de modifier la valeur par défaut d'un paramètre directement dans la liste des valeurs. De plus, il est possible de créer un nouveau paramètre en spécifiant le package, le code, la section, le titre, le type, le contrôle de formulaire, ainsi que l'option de multilinguisme.


### PR DESCRIPTION
## Summary
- adjust top-level headings to start at H2 to match MkDocs structure
- update subsections to H3 where needed

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_b_68935d8c69748325901428217ebb1e31